### PR TITLE
fix: הוספת renameRoom ל-imports של server.ts (תיקון build שרת)

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -8,7 +8,7 @@ import { OAuth2Client } from 'google-auth-library';
 import { createHmac, timingSafeEqual } from 'crypto';
 import webpush from 'web-push';
 import {
-  initDb, getRooms, createRoom, roomExists, getRoomCount,
+  initDb, getRooms, createRoom, roomExists, getRoomCount, renameRoom,
   getRecentMessages, saveMessage,
   savePushSubscription, getPushSubscriptionsForRoom, deletePushSubscription,
   unsubscribeUserFromRoom,


### PR DESCRIPTION
## בעיה

בעקבות מיזוג PR #29, ה-build של השרת נכשל:

```
server.ts(385,11): error TS2552: Cannot find name 'renameRoom'. Did you mean 'createRoom'?
```

הפונקציה `renameRoom` נוספה ל-`db.ts` אך לא נכללה ב-import statement ב-`server.ts`.

## תיקון

הוספת `renameRoom` לשורת ה-import מ-`./db` ב-`server.ts`.

Fixes server build failure from #29