### PR TITLE
✨ Mobile fix, message grouping & loading screen (#32 #33 #34)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -117,6 +117,32 @@ async function unsubscribePushForRoom(email: string, room: string): Promise<void
   });
 }
 
+// ── Message grouping helper (Issue #33) ─────────────────────────────────────
+
+interface MessageGroup {
+  key: string;
+  email: string;
+  username: string;
+  messages: Message[];
+}
+
+function groupMessages(messages: Message[]): MessageGroup[] {
+  const groups: MessageGroup[] = [];
+  for (const msg of messages) {
+    const last = groups[groups.length - 1];
+    if (
+      last &&
+      last.email === msg.email &&
+      msg.timestamp - last.messages[last.messages.length - 1]!.timestamp < 600_000
+    ) {
+      last.messages.push(msg);
+    } else {
+      groups.push({ key: msg.id, email: msg.email, username: msg.username, messages: [msg] });
+    }
+  }
+  return groups;
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export default function ChatApp() {
@@ -136,6 +162,8 @@ export default function ChatApp() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [editingRoom, setEditingRoom] = useState<string | null>(null);
   const [editRoomName, setEditRoomName] = useState('');
+  const [isReady, setIsReady] = useState(false);
+  const [expandedTimestamps, setExpandedTimestamps] = useState<Set<string>>(new Set());
   const [roomNotifications, setRoomNotifications] = useState<Record<string, boolean>>(() => {
     try { return JSON.parse(localStorage.getItem(NOTIF_KEY) || '{}'); } catch { return {}; }
   });
@@ -252,7 +280,10 @@ export default function ChatApp() {
       setMessages(prev => prev.map(m => m.room === oldName ? { ...m, room: newName } : m));
     });
 
-    newSocket.on('previous_messages', (msgs: Message[]) => setMessages(msgs));
+    newSocket.on('previous_messages', (msgs: Message[]) => {
+      setMessages(msgs);
+      setIsReady(true);
+    });
     newSocket.on('new_message', (msg: Message) => setMessages(prev => [...prev, msg]));
 
     newSocket.on('users-update', ({ users: updatedUsers }: { users: UserJoinedData['users'] }) => {
@@ -450,6 +481,15 @@ export default function ChatApp() {
     );
   }
 
+  if (isAuthenticated && !isReady) {
+    return (
+      <div className="connecting-screen">
+        <div className="connecting-spinner" />
+        <p className="connecting-text">מתחבר לצ׳אט...</p>
+      </div>
+    );
+  }
+
   return (
     <div className="chat-container">
       <div className={`sidebar-overlay ${isSidebarOpen ? 'open' : ''}`} onClick={() => setIsSidebarOpen(false)} />
@@ -550,26 +590,36 @@ export default function ChatApp() {
         </div>
 
         <div className="messages-area">
-          {messages.map((msg: Message, idx: number) => {
-            const prev = messages[idx - 1];
-            const isGrouped =
-              !!prev &&
-              prev.email === msg.email &&
-              msg.timestamp - prev.timestamp < 600_000;
-            const isOwn = msg.username === username;
+          {groupMessages(messages).map((group) => {
+            const isOwn = group.username === username;
             return (
-              <div key={msg.id} className={`message${isGrouped ? ' grouped' : ''}`}>
-                <div className={`message-bubble ${isOwn ? 'own' : 'other'}`}>
-                  {!isOwn && !isGrouped && (
+              <div key={group.key} className={`message-group ${isOwn ? 'own' : 'other'}`}>
+                {!isOwn && (
+                  <div
+                    className="message-group-header"
+                    style={{ color: getUserColor(group.email) }}
+                  >
+                    {group.username}
+                    <span className="message-group-time">{formatTime(group.messages[0]!.timestamp)}</span>
+                  </div>
+                )}
+                <div className="message-group-body">
+                  {group.messages.map((msg) => (
                     <div
-                      className="message-sender"
-                      style={{ color: getUserColor(msg.email) }}
+                      key={msg.id}
+                      className={`message-line ${isOwn ? 'own' : 'other'}`}
+                      onClick={() => setExpandedTimestamps(prev => {
+                        const next = new Set(prev);
+                        next.has(msg.id) ? next.delete(msg.id) : next.add(msg.id);
+                        return next;
+                      })}
                     >
-                      {msg.username}
+                      <span className="message-line-text">{msg.text}</span>
+                      {(expandedTimestamps.has(msg.id) || (isOwn && group.messages.length === 1)) && (
+                        <span className="message-line-timestamp">{formatTime(msg.timestamp)}</span>
+                      )}
                     </div>
-                  )}
-                  <div className="message-text">{msg.text}</div>
-                  <div className="message-time">{formatTime(msg.timestamp)}</div>
+                  ))}
                 </div>
               </div>
             );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -8,12 +8,13 @@
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    min-height: 100vh;
+    min-height: 100dvh;
     line-height: 1.6;
+    overflow: hidden;
 }
 
 #root {
-    min-height: 100vh;
+    min-height: 100dvh;
     width: 100%;
 }
 
@@ -36,7 +37,7 @@ input, textarea {
    Login Page
 ───────────────────────────────────────── */
 .login-container {
-    min-height: 100vh;
+    min-height: 100dvh;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -64,7 +65,9 @@ input, textarea {
    Chat Layout — Desktop First
 ───────────────────────────────────────── */
 .chat-container {
-    height: 100vh;
+    height: 100dvh;
+    position: fixed;
+    inset: 0;
     display: flex;
     background: white;
     position: relative;
@@ -356,18 +359,9 @@ input, textarea {
     -webkit-overflow-scrolling: touch;
 }
 
-.message {
-    margin-bottom: 16px;
-    display: flex;
-}
-
-/* Issue #23 — consecutive messages from same user */
-.message.grouped {
-    margin-bottom: 2px;
-}
-
 .message.system {
     justify-content: center;
+    margin-bottom: 8px;
 }
 
 .system-message {
@@ -378,40 +372,98 @@ input, textarea {
     font-size: 13px;
 }
 
-.message-bubble {
-    max-width: 70%;
-    padding: 12px 16px;
-    border-radius: 18px;
-    word-wrap: break-word;
-    word-break: break-word;
+/* ── Message Groups (Issue #33) ── */
+.message-group {
+    margin-bottom: 12px;
+    display: flex;
+    flex-direction: column;
 }
 
-.message-bubble.own {
-    background: #3b82f6;
-    color: white;
-    margin-inline-start: auto;
+.message-group.own {
+    align-items: flex-end;
 }
 
-.message-bubble.other {
-    background: white;
-    color: #374151;
-    border: 1px solid #e5e7eb;
+.message-group.other {
+    align-items: flex-start;
 }
 
-.message-sender {
+.message-group-header {
     font-size: 12px;
     font-weight: 600;
     margin-bottom: 4px;
-    opacity: 0.8;
+    padding-inline-start: 4px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
-.message-text {
-    margin-bottom: 4px;
-}
-
-.message-time {
+.message-group-time {
     font-size: 11px;
+    font-weight: 400;
+    color: #9ca3af;
+}
+
+.message-group-body {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-width: 70%;
+}
+
+.message-group.own .message-group-body {
+    align-items: flex-end;
+}
+
+.message-group.other .message-group-body {
+    align-items: flex-start;
+}
+
+.message-line {
+    padding: 8px 14px;
+    border-radius: 18px;
+    word-wrap: break-word;
+    word-break: break-word;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.message-line.own {
+    background: #3b82f6;
+    color: white;
+    border-bottom-right-radius: 6px;
+}
+
+.message-line.other {
+    background: white;
+    color: #374151;
+    border: 1px solid #e5e7eb;
+    border-bottom-left-radius: 6px;
+}
+
+/* first/last radius in group */
+.message-group.own .message-line:not(:last-child) {
+    border-bottom-right-radius: 4px;
+}
+.message-group.own .message-line:not(:first-child) {
+    border-top-right-radius: 4px;
+}
+.message-group.other .message-line:not(:last-child) {
+    border-bottom-left-radius: 4px;
+}
+.message-group.other .message-line:not(:first-child) {
+    border-top-left-radius: 4px;
+}
+
+.message-line-text {
+    line-height: 1.4;
+}
+
+.message-line-timestamp {
+    font-size: 10px;
     opacity: 0.6;
+    align-self: flex-end;
 }
 
 .typing-indicator {
@@ -815,4 +867,34 @@ body {
   }
 }
 
+/* ── Connecting screen (Issue #34) ── */
+.connecting-screen {
+    height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    gap: 16px;
+}
+
+.connecting-spinner {
+    width: 48px;
+    height: 48px;
+    border: 4px solid rgba(255,255,255,0.3);
+    border-top-color: white;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.connecting-text {
+    color: white;
+    font-size: 16px;
+    font-weight: 500;
+    opacity: 0.9;
+}
 


### PR DESCRIPTION
## סגירת Issues #32, #33, #34

---

### #32 — Mobile Viewport: Header נחתך

**`index.css`**:
- כל ה-`100vh` הוחלפו ב-`100dvh` (Dynamic Viewport Height) — מטפל בשורת הכתובת של Safari/Chrome מובייל
- `.chat-container` קיבל `position: fixed; inset: 0` — מונע גלילה ברמת ה-body לחלוטין
- `body` קיבל `overflow: hidden`

---

### #33 — Message Grouping: עיצוב מחדש

**`App.tsx`**:
- פונקציה חדשה `groupMessages(messages): MessageGroup[]` — מקבצת הודעות עוקבות מאותו email בטווח < 10 דקות
- רינדור לפי groups: header עם שם + צבע + זמן ראשון, ואחריו שורות הודעה
- State `expandedTimestamps: Set<string>` — לחיצה על הודעה עושה toggle לtimestamp שלה
- הודעות של המשתמש עצמו מציגות timestamp כשיש רק הודעה אחת בgroup

**`index.css`**:
- הוסרו: `.message-bubble`, `.message-sender`, `.message-text`, `.message-time`
- נוספו: `.message-group`, `.message-group-header`, `.message-group-body`, `.message-line`, `.message-line-text`, `.message-line-timestamp`
- רדיוס פינות חכם — פינות פנימיות של הgroup מוקטנות, חיצוניות עגולות

---

### #34 — Loading screen: מניעת כניסה מוקדמת לצ'אט

**`App.tsx`**:
- State חדש `isReady` — מתחיל `false`, הופך `true` רק עם קבלת `previous_messages` מה-socket
- `switchRoom` מאפס `isReady=false` בכל מעבר חדר
- כשהמשתמש מאומת אך `!isReady` — מוצג מסך ספינר "מתחבר לצ'אט..."

**`index.css`**: `.connecting-screen`, `.connecting-spinner` (animation), `.connecting-text`

---

Closes #32
Closes #33
Closes #34